### PR TITLE
updating to work with 2018 standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Usage:
     $valid = validate_request( $guid, $userid );
     if ( ! $valid['success'] )  {
         error_log( 'Request failed: ' . $valid['message'] );
+        header("HTTP/1.1 400 Bad Request");
         die();
     }
 

--- a/valid_request.php
+++ b/valid_request.php
@@ -114,7 +114,7 @@ function valid_key_chain_uri( $keychainUri ){
 */
 function valid_ids( $guid, $userid, $data ) {
 
-    $applicationIdValidation    = 'amzn1.echo-sdk-ams.app.' . $guid;
+    $applicationIdValidation    = 'amzn1.ask.skill.' . $guid;
     $userIdValidation1          = 'amzn1.echo-sdk-account.' . $userid;
     $userIdValidation2          = 'amzn1.ask.account.' . $userid;
 


### PR DESCRIPTION
Failing the validation should return a HTTP error code 400 to align with the new requirements from Amazon. 

I just submitted a custom skill with this change.